### PR TITLE
Results is a list of tuples so we need to splat it here

### DIFF
--- a/txredisapi.py
+++ b/txredisapi.py
@@ -1489,7 +1489,7 @@ class BaseRedisProtocol(LineReceiver, policies.TimeoutMixin):
         d = defer.DeferredList(
             deferredList=replies,
             consumeErrors=True,
-            )
+        )
 
         d.addBoth(self._clear_pipeline_state)
 
@@ -1498,7 +1498,7 @@ class BaseRedisProtocol(LineReceiver, policies.TimeoutMixin):
         self.pipelined_replies = []
 
         results = yield d
-        successes, values = zip(results)
+        successes, values = zip(*results)
 
         if all(successes):
             defer.returnValue(values)


### PR DESCRIPTION
Without this change `fig up` reports the following error:

```
[ERROR]
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/twisted/internet/ine 1126, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/usr/local/lib/python2.7/dist-packages/twisted/python/ line 389, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "/txredisapi/tests/test_pipelining.py", line 87, in ion
    yield self._assert_simple_sets_on_pipeline(db=db)
  File "/usr/local/lib/python2.7/dist-packages/twisted/internet/ine 1126, in _inlineCallbacks
    result = result.throwExceptionIntoGenerator(g)
  File "/usr/local/lib/python2.7/dist-packages/twisted/python/ line 389, in throwExceptionIntoGenerator
    return g.throw(self.type, self.value, self.tb)
  File "/txredisapi/tests/test_pipelining.py", line 61, in le_sets_on_pipeline
    yield pipeline.execute_pipeline()
  File "/usr/local/lib/python2.7/dist-packages/twisted/internet/ine 1128, in _inlineCallbacks
    result = g.send(result)
  File "/txredisapi/tests/../txredisapi.py", line 1501, in line
    successes, values = zip(results)
exceptions.ValueError: too many values to unpack

    result = g.send(result)
  File "/txredisapi/tests/../txredisapi.py", line 1501, in line
    successes, values = zip(results)
exceptions.ValueError: too many values to unpack

tests.test_pipelining.TestRedisConnections.test_lazyConnectionPool
===================================================================
[ERROR]
Traceback (most recent call last):
Failure: twisted.trial.util.DirtyReactorAggregateError: Reactor 
Selectables:
<<class 'twisted.internet.tcp.Client'> to ('dbredis_1', 6379) at >
<<class 'twisted.internet.tcp.Client'> to ('dbredis_1', 6379) at >
<<class 'twisted.internet.tcp.Client'> to ('dbredis_1', 6379) at >
<<class 'twisted.internet.tcp.Client'> to ('dbredis_1', 6379) at >
<<class 'twisted.internet.tcp.Client'> to ('dbredis_1', 6379) at >
<<class 'twisted.internet.tcp.Client'> to ('dbredis_1', 6379) at >
<<class 'twisted.internet.tcp.Client'> to ('dbredis_1', 6379) at >
<<class 'twisted.internet.tcp.Client'> to ('dbredis_1', 6379) at >
<<class 'twisted.internet.tcp.Client'> to ('dbredis_1', 6379) at >
<<class 'twisted.internet.tcp.Client'> to ('dbredis_1', 6379) at >

tests.test_pipelining.TestRedisConnections.test_lazyConnectionPool
-------------------------------------------------------------------
Ran 143 tests in 9.156s

FAILED (skips=7, errors=12, successes=130)
txredisapi_web_1 exited with code 1
Gracefully stopping... (press Ctrl+C again to force)
Stopping txredisapi_dbredis_1...
```
